### PR TITLE
Fix completion bar colors not updating when switching profiles

### DIFF
--- a/profiles/js/functions.js
+++ b/profiles/js/functions.js
@@ -351,6 +351,14 @@ async function FillData(uid, mode, completeReload = true) {
     if (oData.user_achievements_total.global_rank != null) document.getElementById("medal__rank__global").innerHTML = "#" + FormatNumber(oData.user_achievements_total.global_rank);
     if (oData.user_achievements_total.completion != null) {
       document.getElementById("completion__bar").style = "width: " + oData.user_achievements_total.completion + "%;";
+      document.getElementById("completion__bar__scheme").classList.forEach((v, k) => {
+        if (v == "col95club" ||
+          v == "col90club" ||
+          v == "col80club" ||
+          v == "col60club" ||
+          v == "col40club")
+            document.getElementById("completion__bar__scheme").classList.remove(v)
+      });
       document.getElementById("completion__bar__scheme").classList.add(ColorizeBar(oData.user_achievements_total.completion));
       // completion = user_achievements_total.completion (88,12%)
       // medalcount = Object.keys(oData.user_achievements).length (230)


### PR DESCRIPTION
fixes #10 . Turns out that we are not clearing the classList of `completion__bar__scheme` when we change profiles, so when it changes profiles the classlist has more than one color class