### PR TITLE
Fix comments being able to go long boi

### DIFF
--- a/global/css/comments.css
+++ b/global/css/comments.css
@@ -107,7 +107,6 @@
     flex: 1;
     max-width: 100%;
     min-width: 0;
-    
     align-self: stretch;
 }
 

--- a/global/css/comments.css
+++ b/global/css/comments.css
@@ -106,6 +106,8 @@
     margin-left: 17px;
     flex: 1;
     max-width: 100%;
+    min-width: 0;
+    
     align-self: stretch;
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/33783503/204349530-51206ee0-4260-4c8b-8433-9b79a8ccfcce.png)
it can still be wider than the container but the container keeps it's width in that case
closes #13