### PR TITLE
Fixes "Long strings of text break profile width"

### DIFF
--- a/global/css/comments.css
+++ b/global/css/comments.css
@@ -212,6 +212,7 @@
     font-size: 14px;
     font-weight: 300;
     white-space: pre-line;
+    word-break: break-word;
 }
 
 .comments__comment-top-text a {

--- a/global/css/main.css
+++ b/global/css/main.css
@@ -818,9 +818,10 @@ a {
 }
 
 .osekai__2col_col1, .osekai__2col_col2 {
-    flex: 25%;
+    flex: 1;
     transition: all 0.8s ease;
-    max-width: calc((100vw - 84px) / 2);
+    max-width: 100%;
+    min-width: 0;
 }
 
 @media screen and (max-width: 1200px) {
@@ -828,9 +829,7 @@ a {
         gap: 0px;
         flex-direction: column;
     }
-    .osekai__2col_col1, .osekai__2col_col2 {
-        max-width: initial;
-    }
+    
     .osekai__2col_col2 {
         margin-top: 00px;
     }

--- a/global/css/main.css
+++ b/global/css/main.css
@@ -820,6 +820,7 @@ a {
 .osekai__2col_col1, .osekai__2col_col2 {
     flex: 25%;
     transition: all 0.8s ease;
+    max-width: calc((100vw - 84px) / 2);
 }
 
 @media screen and (max-width: 1200px) {
@@ -827,7 +828,9 @@ a {
         gap: 0px;
         flex-direction: column;
     }
-
+    .osekai__2col_col1, .osekai__2col_col2 {
+        max-width: initial;
+    }
     .osekai__2col_col2 {
         margin-top: 00px;
     }

--- a/profiles/css/main.css
+++ b/profiles/css/main.css
@@ -149,6 +149,13 @@
     font-weight: 500;
 }
 
+.profiles__cover-back-info_text p:not(#arrival__date):not(#hardware) {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow-x: hidden;
+    max-width: calc((100vw - 48px) / 2 - 61px);
+}
+
 .profiles__cover-back-info_text p .light {
     font-weight: 100;
     opacity: 0.7;

--- a/profiles/css/main.css
+++ b/profiles/css/main.css
@@ -155,6 +155,12 @@
     overflow-x: hidden;
     max-width: calc((100vw - 48px) / 2 - 61px);
 }
+  
+@media screen and (max-width: 1200px) {
+    .profiles__cover-back-info_text p:not(#arrival__date):not(#hardware) {
+        max-width: calc(100vw - 88px);
+    }
+}
 
 .profiles__cover-back-info_text p .light {
     font-weight: 100;
@@ -1276,6 +1282,10 @@ input[type=number] {
 
     .profiles__panel-row {
         flex-direction: column;
+    }
+
+    .profiles__cover-back-info_text p:not(#arrival__date):not(#hardware) {
+        max-width: calc(100vw - 62px);
     }
 }
 

--- a/profiles/css/main.css
+++ b/profiles/css/main.css
@@ -144,6 +144,10 @@
     align-items: center;
 }
 
+.profiles__cover-back-info_text {
+    max-width: 100%;
+}
+
 .profiles__cover-back-info_text p {
     font-size: 15px;
     font-weight: 500;
@@ -153,13 +157,6 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow-x: hidden;
-    max-width: calc((100vw - 48px) / 2 - 61px);
-}
-  
-@media screen and (max-width: 1200px) {
-    .profiles__cover-back-info_text p:not(#arrival__date):not(#hardware) {
-        max-width: calc(100vw - 88px);
-    }
 }
 
 .profiles__cover-back-info_text p .light {
@@ -1282,10 +1279,6 @@ input[type=number] {
 
     .profiles__panel-row {
         flex-direction: column;
-    }
-
-    .profiles__cover-back-info_text p:not(#arrival__date):not(#hardware) {
-        max-width: calc(100vw - 62px);
     }
 }
 


### PR DESCRIPTION
fixes #43 
I edited the css of general (global), which may have interfered with other pages.

Best code for testing styles:
```html
<style>
.osekai__2col_col1, .osekai__2col_col2 {
    flex: 1;
    max-width: 100%;
    min-width: 0;
}

.profiles__cover-back-info_text {
    max-width: 100%;
}

.profiles__cover-back-info_text p:not(#arrival__date):not(#hardware) {
    text-overflow: ellipsis;
    white-space: nowrap;
    overflow-x: hidden;
}

.comments__comment-top-text {
    word-break: break-word;
}
</style>
```