### PR TITLE
Change home panel img border radius to 16px

### DIFF
--- a/home/css/main.css
+++ b/home/css/main.css
@@ -239,7 +239,7 @@
 }
 
 .home__panel-img {
-    border-radius: 8px;
+    border-radius: 16px;
     border: 1px solid rgb(var(--paccent-bright));
     box-sizing: border-box;
     height: 21vw;


### PR DESCRIPTION
Now homepage images dont go out of the box, they match the edges nicely

| before | after |
| --| -- |
| ![image](https://user-images.githubusercontent.com/30161277/204602124-e344699c-9cc5-4e3f-a3bb-5172f8ed5960.png)|![image](https://user-images.githubusercontent.com/30161277/204602223-777d9b10-a250-4507-8ec0-e595a6ee15c8.png)|
