### PR TITLE
Fix expired timer in osu_api_functions

### DIFF
--- a/global/php/osu_api_functions.php
+++ b/global/php/osu_api_functions.php
@@ -26,10 +26,10 @@ function GetBearer()
 function IsExpired()
 {
     if (isset($_SESSION['access_token_expiration'])) {
-        $timer = intval($_SESSION['access_token_expiration']);
+        $timer = intval($_SESSION['access_token_timer']);
         $expiration = $_SESSION['access_token_expiration'] + $timer;
         $date = new DateTime();
-        return $expiration > $date->getTimestamp();
+        return $expiration < $date->getTimestamp();
     } else {
         return true;
     }


### PR DESCRIPTION
i'm not sure why this was wrong, and on top of that it was working absolutely fine in prod, just breaking down completely on my local instance. It seemed wrong to begin with, so this is probably for the best