### PR TITLE
Make thin variants on other languages more readable

### DIFF
--- a/global/php/osekaiLocalization.php
+++ b/global/php/osekaiLocalization.php
@@ -88,7 +88,7 @@ $locales = [
         "flag" => "https://assets.ppy.sh/old-flags/KR.png",
         "extra_html" => '<link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100;300;400;500;700;900&display=swap" rel="stylesheet">',
+        <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700;900&display=swap" rel="stylesheet">',
         "extra_css" => 'body { font-family: "Comfortaa", "Noto Sans KR", sans-serif !important; }',
     ],
     "ja_JP" => [
@@ -99,7 +99,7 @@ $locales = [
         "flag" => "https://assets.ppy.sh/old-flags/JP.png",
         "extra_html" => '<link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@100;300;400;500;700;800;900&display=swap" rel="stylesheet"> ',
+        <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500;700;800;900&display=swap" rel="stylesheet"> ',
         "extra_css" => 'body { font-family: "Comfortaa", "M PLUS Rounded 1c", sans-serif !important; }',
     ],
     /* chinese simplified */
@@ -119,7 +119,7 @@ $locales = [
         "flag" => "https://assets.ppy.sh/old-flags/TW.png",
         "extra_html" => '<link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@100;300;400;500;700&display=swap" rel="stylesheet"> ',
+        <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700&display=swap" rel="stylesheet"> ',
         "extra_css" => 'body { font-family: "Comfortaa", "Noto Sans TC", sans-serif !important; }',
     ],
     /* hebrew */
@@ -134,7 +134,7 @@ $locales = [
         "rtl" => true,
         "extra_html" => '<link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@100;300;400;500;700;800;900&display=swap" rel="stylesheet"> ',
+        <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500;700;800;900&display=swap" rel="stylesheet"> ',
         "extra_css" => 'body { font-family: "Comfortaa", "M PLUS Rounded 1c", sans-serif !important; }',
     ],
     /* italian */


### PR DESCRIPTION
This removes the 100 and 300 font weights from some languages, as the fonts were much too thin to read in my opinion.

Before / after
![image](https://user-images.githubusercontent.com/33783503/207633672-09e0b49a-6e50-4f51-8393-f88abb728b71.png)
![image](https://user-images.githubusercontent.com/33783503/207633719-f76fb1ca-aeda-4b0e-a81a-9768c24b6c3b.png)
![image](https://user-images.githubusercontent.com/33783503/207633746-b51ccd29-f2ca-4350-b0dc-2ffab05df78c.png)
![image](https://user-images.githubusercontent.com/33783503/207633783-33ad179d-9d15-4b5f-a06f-6d8b375bafa3.png)
