### PR TITLE
gitinfo: Refactor the thing

### DIFF
--- a/global/css/main.css
+++ b/global/css/main.css
@@ -3959,7 +3959,7 @@ figcaption {
     right: 0;
     bottom: 10px;
     /*  backdrop-filter: blur(20px); */
-    transform: translateX(400px);
+    transform: translateX(475px);
     display: flex;
     align-items: center;
     transition: all 0.6s ease;
@@ -3983,7 +3983,7 @@ figcaption {
 }
 
 .debug__inner {
-    width: 400px;
+    width: 475px;
     font-family: monospace;
     font-size: 15px;
     background: #111c;

--- a/global/php/functionsEnd.php
+++ b/global/php/functionsEnd.php
@@ -34,7 +34,9 @@ $tooltipText = "This debug panel is so that you, and our team, can make sure Ose
         <p><?php echo GetStringRaw("general", "page.generatedIn", ["<strong>" . $time . "</strong>"]); ?></p>
         <p>Aborted Session Saves: <strong><?php echo $abortedSaves; ?></strong></p>
         <p style="font-size: 10px">Commit <strong><a href="https://github.com/Osekai/osekai/commit/<?= $gitHash ?>"><?= $gitHash ?></a></strong>
-            (branch <strong><a href="https://github.com/Osekai/osekai/tree/<?= $gitBranchName ?>"><?= $gitBranchName ?></a></strong>)</p>
+            (branch <strong>
+                <?= $gitBranchLink != "" ? '<a href="' . $gitBranchLink . '">' . $gitBranchName . '</a>' : $gitBranchName ?></strong>)
+
         <p style="font-size: 10px"><?= $gitDate; ?> UTC</p>
     </div>
 </div>

--- a/global/php/gitInfo.php
+++ b/global/php/gitInfo.php
@@ -1,7 +1,41 @@
 <?php
 $gitBasePath = $_SERVER['DOCUMENT_ROOT']  . '/.git'; // e.g in laravel: base_path().'/.git';
 $gitStr = file_get_contents($gitBasePath . '/HEAD');
-$gitBranchName = rtrim(preg_replace("/(.*?\/){2}/", '', $gitStr));
-$gitPathBranch = $gitBasePath . '/refs/heads/' . $gitBranchName;
-$gitHash = file_get_contents($gitPathBranch);
-$gitDate = gmdate("Y-m-d@H:i:s", filemtime($gitPathBranch));
+
+// on PR
+// ref: refs/heads/pr/username/prID
+$isPR = str_starts_with($gitStr, "ref: refs/heads/pr/");
+$gitBranchLink = ""; // Leave null for detached head or for other cases where link is not handled
+
+if ($isPR) {
+    $gitBranchName = rtrim(str_replace("ref: refs/heads/", '', $gitStr));
+
+    $gitHash = getCurrentCommitHash();
+    $gitDate = gmdate("Y-m-d@H:i:s", getDateFromCommitHash($gitHash));
+
+    $prNumber = rtrim(preg_replace("/(.*?\/){2}/", '', $gitBranchName));
+    $gitBranchLink = "https://github.com/Osekai/osekai/pull/" . $prNumber;
+} else {
+    $gitBranchName = rtrim(preg_replace("/(.*?\/){2}/", '', $gitStr));
+
+    $isDetachedHead =  getCurrentCommitHash() == $gitBranchName;
+    if ($isDetachedHead) {
+        $gitBranchName = "HEAD";
+    } else {
+        $gitBranchLink = "https://github.com/Osekai/osekai/tree/" . $gitBranchName;
+    }
+
+    $gitHash = getCurrentCommitHash();
+    $gitDate = gmdate("Y-m-d@H:i:s", getDateFromCommitHash($gitHash));
+}
+
+function getCurrentCommitHash()
+{
+    return rtrim(shell_exec("git rev-parse HEAD"));
+}
+
+function getDateFromCommitHash($hash)
+{
+    $output = shell_exec("git show -s --format=%ct " . $hash);
+    return intval($output);
+}


### PR DESCRIPTION
https://user-images.githubusercontent.com/30161277/210027497-7009031b-90dd-4ce8-945e-6bc13119b112.mp4

on normal branchs it works as expected, like before
detached head: show show `HEAD` as branch name without any link
on pr: show `pr/username/prId` as branch name with link the the pull request

also now the date uses the actual date of the commit, not the last time of the modified file
currently on mobiles it looks a bit cut of because of the wider debug panel, had to do it to fit the pr branch names c:, so i need a way to make it look nicer on phones