### PR TITLE
profiles: Preload user pfp when loading user

### DIFF
--- a/profiles/js/functions.js
+++ b/profiles/js/functions.js
@@ -145,6 +145,7 @@ function loadUser(uid) {
     let url = new URL(window.location);
     url.searchParams.set('user', uid);
     window.history.pushState({}, '', url);
+    document.querySelectorAll("[selector='pfp']").forEach((oPfp) => { oPfp.src = `https://a.ppy.sh/${uid}` });
     document.getElementById('profile').classList.remove('hidden');
     document.getElementById('home').classList.add('hidden');
     loadMode(null);


### PR DESCRIPTION
Instead of defaulting to ppy or guest avatar when loading the user, it will now actually use the user avatar, tested, works very nice
video:

https://user-images.githubusercontent.com/30161277/228112164-e7993796-c3b6-4665-8fc1-213b72b10fac.mp4

you can see how before the profile finishes loading, both user bar and and main pfp are already set to the user's pfp