### PR TITLE
Fix background clipping in medals page if too few comments.

### DIFF
--- a/global/css/comments.css
+++ b/global/css/comments.css
@@ -392,6 +392,7 @@
     transform: translateY(20px);
     opacity: 0;
     pointer-events: none;
+    display: none;
 }
 
 .comments__input-box {


### PR DESCRIPTION
Clipping can still be seen if emote picker is open on low comment medal pages. But this just gets rid of the annoyance..

![image](https://user-images.githubusercontent.com/37494321/236852466-485ff0fe-254f-4fe2-be46-1076f1d57b62.png)
before

![image](https://user-images.githubusercontent.com/37494321/236852497-8cdaf9e7-80c1-4016-a86a-8c9bd7fcad17.png)
After

![image](https://user-images.githubusercontent.com/37494321/236852532-a40bbc3c-6550-4e6c-9cb4-a9a92d123417.png)
After with emote picker